### PR TITLE
Datadog tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,3 +162,14 @@ task xray_generation_and_splunk_siem_test(type: Test) {
         showStandardStreams = true
     }
 }
+
+task datadog_siem_test_only(type: Test) {
+    useTestNG() {
+        useDefaultListeners = true
+        suites 'src/test/groovy/testng.xml'
+        includeGroups("datadog_siem")
+    }
+    testLogging {
+        showStandardStreams = true
+    }
+}

--- a/src/test/groovy/steps/DatadogSteps.groovy
+++ b/src/test/groovy/steps/DatadogSteps.groovy
@@ -29,5 +29,19 @@ class DatadogSteps {
                 .extract().response()
     }
 
+    static def aggregateLogs(dd_url, api_key, application_key, query) {
+        return given()
+                .relaxedHTTPSValidation()
+                .header("Cache-Control", "no-cache")
+                .header("Content-Type", "application/json")
+                .header("DD-API-KEY", api_key)
+                .header("DD-APPLICATION-KEY", application_key)
+                .body(query)
+                .when()
+                .post(dd_url + "/api/v2/logs/analytics/aggregate")
+                .then()
+                .extract().response()
+    }
+
 
 }

--- a/src/test/groovy/steps/DatadogSteps.groovy
+++ b/src/test/groovy/steps/DatadogSteps.groovy
@@ -4,6 +4,8 @@ import io.restassured.response.Response
 import org.hamcrest.Matchers
 import org.yaml.snakeyaml.Yaml
 
+import java.util.stream.Collectors
+
 import static io.restassured.RestAssured.given
 
 class DatadogSteps {
@@ -65,6 +67,32 @@ class DatadogSteps {
             cursor = response.jsonPath().get("meta.page.after")
         } while (cursor)
         return counts
+    }
+
+    static Map<String, Integer> renameMapKeysForWatches(Map<String, Integer> map) {
+        return map.collect().stream().collect(
+                Collectors.toMap(
+                        {Map.Entry<String, Integer> it -> it.key.contains("security") ? "security" : it.key.substring(it.key.lastIndexOf("_")+1)},
+                        {Map.Entry<String, Integer> it -> it.value},
+                        Integer::sum
+                )
+        )
+    }
+
+    static Map<String, Integer> renameMapKeysForPolicies(Map<String, Integer> map) {
+        return map.collect().stream().collect(
+                Collectors.toMap(
+                        {Map.Entry<String, Integer> it ->
+                            it.key.contains("security") ? "security" : (
+                                    it.key.contains("License") && it.key.contains("Rule")
+                                    ? it.key.substring("License".length(), it.key.lastIndexOf("Rule"))
+                                    : it.key
+                            )
+                        },
+                        {Map.Entry<String, Integer> it -> it.value},
+                        Integer::sum
+                )
+        )
     }
 
 

--- a/src/test/groovy/steps/SplunkSteps.groovy
+++ b/src/test/groovy/steps/SplunkSteps.groovy
@@ -98,32 +98,6 @@ class SplunkSteps {
         )
     }
 
-    static Map<String, Integer> getExpectedSeverities(license_issues, security_issues) {
-        Map<String, Integer> expected = security_issues.stream().collect(
-                Collectors.toMap(
-                        {Object[] it -> it[5].toString()},
-                        {Object[] it -> it[6].size()},
-                        Integer::sum
-                )
-        )
-        int licenseCount = license_issues.stream().reduce((int) 0, (int count, list) -> count + list[3].size())
-
-        expected.put("High", expected.getOrDefault("High", 0) + licenseCount)
-        return expected
-    }
-
-    static Map<String, Integer> getExpectedViolationCounts(license_issues, security_issues) {
-        def expected = license_issues.stream().collect(
-                Collectors.toMap(
-                        {Object[] it -> it[0].toString()},
-                        {Object[] it -> it[3].size()},
-                        Integer::sum
-                )
-        )
-
-        expected.put("security", security_issues.stream().reduce((int) 0, (int count, list) -> count + list[6].size()))
-        return expected
-    }
 
     static Map<String, Integer> getMatchedPolicyWatchCounts(Response response, String selector) {
         return response.jsonPath().getList("results").stream().collect(
@@ -178,23 +152,6 @@ class SplunkSteps {
         )
     }
 
-    static Map<String, Integer> getExpectedComponentCounts(license_issues, security_issues) {
-        def componentCounts = new HashMap<String, Integer>()
-        license_issues.forEach { it ->
-            it[3].forEach { artifactId ->
-                def artifactName = XraySteps.artifactFormat(artifactId)
-                componentCounts.put(artifactName, componentCounts.getOrDefault(artifactName, 0) + 1)
-            }
-        }
-
-        security_issues.forEach { it ->
-            it[6].forEach { artifactId ->
-                def artifactName = XraySteps.artifactFormat(artifactId)
-                componentCounts.put(artifactName, componentCounts.getOrDefault(artifactName, 0) + 1)
-            }
-        }
-        return componentCounts
-    }
 
     static Map<String, Integer> getCVECounts(Response response) {
         return response.jsonPath().getList("results").stream().collect(
@@ -206,14 +163,5 @@ class SplunkSteps {
         )
     }
 
-    static Map<String, Integer> getExpectedCVECounts(security_issues) {
-        return security_issues.stream().collect(
-                Collectors.toMap(
-                        it -> it[1].toString(),
-                        it -> it[6].size(),
-                        Integer::sum
-                )
-        )
-    }
 
 }

--- a/src/test/groovy/steps/XraySteps.groovy
+++ b/src/test/groovy/steps/XraySteps.groovy
@@ -14,7 +14,9 @@ import static io.restassured.RestAssured.given
 import static org.hamcrest.Matchers.equalTo
 
 class XraySteps extends TestSetup{
-    public static artifactFormat = {int i -> "artifact_${i}.zip".toString()}
+    static String artifactFormat(int i) {
+        return "artifact_${i}.zip".toString()
+    }
 
     static void deleteExistingWatches(namePrefix, artifactoryBaseURL, username, password) {
         def watches = given()

--- a/src/test/groovy/steps/XraySteps.groovy
+++ b/src/test/groovy/steps/XraySteps.groovy
@@ -8,12 +8,13 @@ import org.testng.annotations.DataProvider
 import tests.TestSetup
 
 import java.util.concurrent.TimeUnit
+import java.util.stream.Collectors
 
 import static io.restassured.RestAssured.given
 import static org.hamcrest.Matchers.equalTo
 
 class XraySteps extends TestSetup{
-    public static artifactFormat = {int i -> "artifact_${i}.zip"}
+    public static artifactFormat = {int i -> "artifact_${i}.zip".toString()}
 
     static void deleteExistingWatches(namePrefix, artifactoryBaseURL, username, password) {
         def watches = given()
@@ -858,6 +859,66 @@ class XraySteps extends TestSetup{
                 .then()
                 .extract().response()
     }
+
+    // Expected Results
+
+    static Map<String, Integer> getExpectedSeverities(license_issues, security_issues) {
+        Map<String, Integer> expected = security_issues.stream().collect(
+                Collectors.toMap(
+                        {Object[] it -> it[5].toString()},
+                        {Object[] it -> it[6].size()},
+                        Integer::sum
+                )
+        )
+        int licenseCount = license_issues.stream().reduce((int) 0, (int count, list) -> count + list[3].size())
+
+        expected.put("High", expected.getOrDefault("High", 0) + licenseCount)
+        return expected
+    }
+
+    static Map<String, Integer> getExpectedComponentCounts(license_issues, security_issues) {
+        def componentCounts = new HashMap<String, Integer>()
+        license_issues.forEach { it ->
+            it[3].forEach { artifactId ->
+                def artifactName = artifactFormat(artifactId)
+                componentCounts.put(artifactName, componentCounts.getOrDefault(artifactName, 0) + 1)
+            }
+        }
+
+        security_issues.forEach { it ->
+            it[6].forEach { artifactId ->
+                def artifactName = artifactFormat(artifactId)
+                componentCounts.put(artifactName, componentCounts.getOrDefault(artifactName, 0) + 1)
+            }
+        }
+        return componentCounts
+    }
+
+
+    static Map<String, Integer> getExpectedViolationCounts(license_issues, security_issues) {
+        def expected = license_issues.stream().collect(
+                Collectors.toMap(
+                        {Object[] it -> it[0].toString()},
+                        {Object[] it -> it[3].size()},
+                        Integer::sum
+                )
+        )
+
+        expected.put("security", security_issues.stream().reduce((int) 0, (int count, list) -> count + list[6].size()))
+        return expected
+    }
+
+
+    static Map<String, Integer> getExpectedCVECounts(security_issues) {
+        return security_issues.stream().collect(
+                Collectors.toMap(
+                        it -> it[1].toString(),
+                        it -> it[6].size(),
+                        Integer::sum
+                )
+        )
+    }
+
 
     // Data providers
 

--- a/src/test/groovy/tests/DatadogTest.groovy
+++ b/src/test/groovy/tests/DatadogTest.groovy
@@ -29,7 +29,7 @@ class DatadogTest extends DataAnalyticsSteps {
     def artifact = new File("./src/test/resources/repositories/artifact.zip")
     def repoSteps = new RepositorySteps()
     def securitySteps = new SecuritytSteps()
-    def datadog = new DatadogSteps("now-5d", "now")
+    def datadog = new DatadogSteps("now-15m", "now")
     def testUsers = ["testuser1", "testuser2", "testuser3", "testuser4"]
     def from_timestamp
     def to_timestamp
@@ -425,6 +425,7 @@ class DatadogTest extends DataAnalyticsSteps {
         )
 
         Assert.assertEquals(watchesCounts.size(), license_issues.size() + 1)
+        Reporter.log("- Datadog, Xray Violations. Count of watches test passed.", true)
     }
 
     @Test(priority = 15, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Vulnerabilities")
@@ -436,6 +437,7 @@ class DatadogTest extends DataAnalyticsSteps {
         // sum of all security
         def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues).getOrDefault("security", 0)
         Assert.assertEquals(response.jsonPath().get("data.buckets[0].computes.c0") ?: 0, expected)
+        Reporter.log("- Datadog, Xray Violations. Count of vulnerabilities test passed.", true)
     }
 
     @Test(priority = 16, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, License Issues")
@@ -448,6 +450,7 @@ class DatadogTest extends DataAnalyticsSteps {
         def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
         expected.remove("security")
         Assert.assertEquals(response.jsonPath().get("data.buckets[0].computes.c0") ?: 0, expected.values().sum())
+        Reporter.log("- Datadog, Xray Violations. Count of licensing issues test passed.", true)
     }
 
     @Test(priority = 17, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Violations")
@@ -459,6 +462,7 @@ class DatadogTest extends DataAnalyticsSteps {
         // sum of all license and security issues
         def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues).values().sum()
         Assert.assertEquals(response.jsonPath().get("data.buckets[0].computes.c0") ?: 0, expected)
+        Reporter.log("- Datadog, Xray Violations. Count of violations test passed.", true)
     }
 
     @Test(priority = 18, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Infected Components")
@@ -469,6 +473,7 @@ class DatadogTest extends DataAnalyticsSteps {
 
         def expected = XraySteps.getExpectedComponentCounts(license_issues, security_issues).size()
         Assert.assertEquals(infectedComponentsCounts.size(), expected)
+        Reporter.log("- Datadog, Xray Violations. Count of infected components test passed.", true)
     }
 
     @Test(priority = 19, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Impacted Artifacts")
@@ -479,6 +484,7 @@ class DatadogTest extends DataAnalyticsSteps {
 
         def expected = XraySteps.getExpectedComponentCounts(license_issues, security_issues).size()
         Assert.assertEquals(impactedArtifactsCounts.size(), expected)
+        Reporter.log("- Datadog, Xray Violations. Count of impacted artifacts test passed.", true)
     }
 
     @Test(priority = 20, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Violations per Watch")
@@ -489,6 +495,7 @@ class DatadogTest extends DataAnalyticsSteps {
         def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
         def actual = DatadogSteps.renameMapKeysForWatches(watchesCounts)
         Assert.assertEquals(actual, expected)
+        Reporter.log("- Datadog, Xray Violations. Violations per watch test passed.", true)
     }
 
     @Test(priority = 21, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Violations Severity")
@@ -498,6 +505,7 @@ class DatadogTest extends DataAnalyticsSteps {
         )
         def expected = XraySteps.getExpectedSeverities(license_issues, security_issues)
         Assert.assertEquals(severities, expected)
+        Reporter.log("- Datadog, Xray Violations. Violations severities test passed.", true)
     }
 
     @Test(priority = 22, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Violations by Policy")
@@ -508,6 +516,7 @@ class DatadogTest extends DataAnalyticsSteps {
         def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
         def actual = DatadogSteps.renameMapKeysForWatches(watchesCounts)
         Assert.assertEquals(actual, expected)
+        Reporter.log("- Datadog, Xray Violations. Violations by Policy test passed.", true)
     }
 
     @Test(priority = 23, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Violations by Rule")
@@ -518,6 +527,7 @@ class DatadogTest extends DataAnalyticsSteps {
         def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
         def actual = DatadogSteps.renameMapKeysForPolicies(rulesCounts)
         Assert.assertEquals(actual, expected)
+        Reporter.log("- Datadog, Xray Violations. Violations by rule test passed.", true)
     }
 
     @Test(priority = 24, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Violation Types over Time (stats)")
@@ -531,6 +541,7 @@ class DatadogTest extends DataAnalyticsSteps {
         def expectedLicenseViolations = expected.values().sum()
 
         Assert.assertEquals(typeCounts, ['License':expectedLicenseViolations, 'Security':expectedSecurityViolations])
+        Reporter.log("- Datadog, Xray Violations. Violations by type test passed.", true)
     }
 
     @Test(priority = 25, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Violation over Time (By Severity)")
@@ -546,6 +557,7 @@ class DatadogTest extends DataAnalyticsSteps {
 
         def expected = XraySteps.getExpectedComponentCounts(license_issues, security_issues)
         Assert.assertEquals(DatadogSteps.extractArtifactNamesToMap(infected), expected)
+        Reporter.log("- Datadog, Xray Violations. Top Infected Components test passed.", true)
     }
 
     @Test(priority = 27, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Top Impacted Artifacts")
@@ -556,6 +568,7 @@ class DatadogTest extends DataAnalyticsSteps {
 
         def expected = XraySteps.getExpectedComponentCounts(license_issues, security_issues)
         Assert.assertEquals(DatadogSteps.extractArtifactNamesToMap(infected), expected)
+        Reporter.log("- Datadog, Xray Violations. Top Impacted Artifacts test passed.", true)
     }
 
     @Test(priority = 28, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Top Vulnerabilities")
@@ -566,6 +579,7 @@ class DatadogTest extends DataAnalyticsSteps {
         def expectedCVECounts = XraySteps.getExpectedCVECounts(security_issues)
 
         Assert.assertEquals(cveCounts, expectedCVECounts)
+        Reporter.log("- Datadog, Xray Violations. Top vulnerabilities test passed.", true)
     }
 
     @Test(priority = 29, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Top Vulnerable Artifact by Count of IP Download")
@@ -574,6 +588,7 @@ class DatadogTest extends DataAnalyticsSteps {
         def expectedArtifactCount = XraySteps.getExpectedComponentCounts(license_issues, security_issues).size()
 
         Assert.assertEquals(artifacts.size(), expectedArtifactCount)
+        Reporter.log("- Datadog, Xray Violations. Top Vulnerable Artifact by Count of IP Download test passed.", true)
     }
 
     @Test(priority = 30, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Top Vulnerable Artifact by Count of User Download")
@@ -582,6 +597,7 @@ class DatadogTest extends DataAnalyticsSteps {
         def expectedArtifactCount = XraySteps.getExpectedComponentCounts(license_issues, security_issues).size()
 
         Assert.assertEquals(artifacts.size(), expectedArtifactCount)
+        Reporter.log("- Datadog, Xray Violations. Top Vulnerable Artifact by Count of User Download test passed.", true)
     }
 
 }

--- a/src/test/groovy/tests/DatadogTest.groovy
+++ b/src/test/groovy/tests/DatadogTest.groovy
@@ -520,4 +520,22 @@ class DatadogTest extends DataAnalyticsSteps {
         Assert.assertEquals(actual, expected)
     }
 
+    @Test(priority = 24, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Violation Types over Time (stats)")
+    void violationTypesOverTimeStatsTest() {
+        def typeCounts = datadog.getMapOfCountLogAggregation(datadogBaseURL, datadogApiKey, datadogApplicationKey,
+                "@log_source:jfrog.xray.siem.vulnerabilities", "@type"
+        )
+
+        def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
+        def expectedSecurityViolations = expected.remove("security") ?: 0
+        def expectedLicenseViolations = expected.values().sum()
+
+        Assert.assertEquals(typeCounts, ['License':expectedLicenseViolations, 'Security':expectedSecurityViolations])
+    }
+
+    @Test(priority = 25, groups = ["datadog_siem"], testName = "Datadog. Xray Violations, Violation over Time (By Severity)")
+    void violationOverTimeSeverityTest() {
+        violationsSeverityCount() // This widget is the exact same as "Violations Severity"
+    }
+
 }

--- a/src/test/groovy/tests/SplunkTest.groovy
+++ b/src/test/groovy/tests/SplunkTest.groovy
@@ -800,7 +800,7 @@ class SplunkTest extends DataAnalyticsSteps{
 
     @Test(priority = 29, groups = ["splunk_siem"], testName = "Xray, Violations. Vulnerabilities")
     void vulnerabilitiesCountTest() throws Exception {
-        def vulnerability_count = SplunkSteps.getExpectedViolationCounts(license_issues, security_issues).getOrDefault("security", 0)
+        def vulnerability_count = XraySteps.getExpectedViolationCounts(license_issues, security_issues).getOrDefault("security", 0)
 
         def search_string = /search=search log_source="jfrog.xray.siem.vulnerabilities" category="Security" earliest=$earliest |/ +
                 /stats count as Vulnerabilities/
@@ -821,7 +821,7 @@ class SplunkTest extends DataAnalyticsSteps{
 
     @Test(priority = 30, groups = ["splunk_siem"], testName = "Xray, Violations. License Issues")
     void licenseIssuesCountTest() throws Exception {
-        def expected = SplunkSteps.getExpectedViolationCounts(license_issues, security_issues)
+        def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
         expected.remove("security")
 
         def search_string = /search=search log_source="jfrog.xray.siem.vulnerabilities" category="License" earliest=$earliest | stats count as licenses/
@@ -849,7 +849,7 @@ class SplunkTest extends DataAnalyticsSteps{
         int size = response.then().extract().body().path("results.size()")
 
         // sum of all security and license issues
-        def expected = SplunkSteps.getExpectedViolationCounts(license_issues, security_issues).values().sum()
+        def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues).values().sum()
 
         if (size == 0){
             Assert.fail("Empty response from Splunk")
@@ -864,7 +864,7 @@ class SplunkTest extends DataAnalyticsSteps{
 
     @Test(priority = 33, groups = ["splunk_siem"], testName = "Xray, Violations. Infected Components")
     void infectedComponentsCountTest() throws Exception {
-        def infected_components_count = SplunkSteps.getExpectedComponentCounts(license_issues, security_issues).size()
+        def infected_components_count = XraySteps.getExpectedComponentCounts(license_issues, security_issues).size()
 
         def search_string = /search=search log_source="jfrog.xray.siem.vulnerabilities" earliest=$earliest | stats dc(infected_components{}) as infected_components/
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
@@ -885,7 +885,7 @@ class SplunkTest extends DataAnalyticsSteps{
 
     @Test(priority = 34, groups = ["splunk_siem"], testName = "Xray, Violations. Impacted Artifacts")
     void impactedArtifactsCountTest() throws Exception {
-        def impacted_artifacts_count = SplunkSteps.getExpectedComponentCounts(license_issues, security_issues).size()
+        def impacted_artifacts_count = XraySteps.getExpectedComponentCounts(license_issues, security_issues).size()
 
         def search_string = /search=search log_source="jfrog.xray.siem.vulnerabilities" earliest=$earliest | stats dc(impacted_artifacts{}) as impacted_artifacts/
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
@@ -909,7 +909,7 @@ class SplunkTest extends DataAnalyticsSteps{
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         def actual = SplunkSteps.getMatchedPolicyWatchCounts(response, "signature")
 
-        def expected = SplunkSteps.getExpectedViolationCounts(license_issues, security_issues)
+        def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
         Assert.assertEquals(actual, expected)
 
         Reporter.log("- Splunk. Xray, Violations, Violations per Watch verification. " +
@@ -922,7 +922,7 @@ class SplunkTest extends DataAnalyticsSteps{
         def search_string = /search=search log_source="jfrog.xray.siem.vulnerabilities" severity!=Unknown earliest=$earliest | stats count by severity/
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         def severities = SplunkSteps.getSeverities(response)
-        def expected = SplunkSteps.getExpectedSeverities(license_issues, security_issues)
+        def expected = XraySteps.getExpectedSeverities(license_issues, security_issues)
 
         Assert.assertEquals(severities, expected)
 
@@ -936,7 +936,7 @@ class SplunkTest extends DataAnalyticsSteps{
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         def actual = SplunkSteps.getMatchedPolicyWatchCounts(response, "matched_policies{}.policy")
 
-        def expected = SplunkSteps.getExpectedViolationCounts(license_issues, security_issues)
+        def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
         Assert.assertEquals(actual, expected)
         Reporter.log("- Splunk. Xray, Violations, Violations by Rule. " +
                 "Splunk shows responses generated by Xray ", true)
@@ -948,7 +948,7 @@ class SplunkTest extends DataAnalyticsSteps{
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         def actual = SplunkSteps.getMatchedRuleCounts(response)
 
-        def expected = SplunkSteps.getExpectedViolationCounts(license_issues, security_issues)
+        def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
         Assert.assertEquals(actual, expected)
         Reporter.log("- Splunk. Xray, Violations, Violations by Rule. " +
                 "Splunk shows responses generated by Xray ", true)
@@ -973,7 +973,7 @@ class SplunkTest extends DataAnalyticsSteps{
                 securityViolationCount = results.stream().reduce(0, { (int count, data) -> count + Integer.parseInt(data["Security"].toString()) } )
             }
         }
-        def expected = SplunkSteps.getExpectedViolationCounts(license_issues, security_issues)
+        def expected = XraySteps.getExpectedViolationCounts(license_issues, security_issues)
         def expectedSecurityViolations = expected.remove("security") ?: 0
         def expectedLicenseViolations = expected.values().sum()
 
@@ -988,7 +988,7 @@ class SplunkTest extends DataAnalyticsSteps{
         def search_string = /search=search log_source="jfrog.xray.siem.vulnerabilities"  severity!="unknown" earliest=$earliest | timechart  count by severity/
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         def severities = SplunkSteps.squashSeveritiesOverTime(response)
-        def expectedSeverities = SplunkSteps.getExpectedSeverities(license_issues, security_issues)
+        def expectedSeverities = XraySteps.getExpectedSeverities(license_issues, security_issues)
 
         Assert.assertEquals(severities, expectedSeverities)
         Reporter.log("- Splunk. Xray, Violations, Violation Types over Time (Severities). " +
@@ -1000,7 +1000,7 @@ class SplunkTest extends DataAnalyticsSteps{
         def search_string = /search=search log_source="jfrog.xray.siem.vulnerabilities" earliest=$earliest | stats count by infected_components{}/
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         def infected = SplunkSteps.getInfectedComponentCounts(response, "infected_components{}")
-        def expected = SplunkSteps.getExpectedComponentCounts(license_issues, security_issues)
+        def expected = XraySteps.getExpectedComponentCounts(license_issues, security_issues)
 
         Assert.assertEquals(infected, expected)
         Reporter.log("- Splunk. Xray, Violations, Top Infected Components. " +
@@ -1012,7 +1012,7 @@ class SplunkTest extends DataAnalyticsSteps{
         def search_string = /search=search log_source="jfrog.xray.siem.vulnerabilities" earliest=$earliest | stats count by impacted_artifacts{}/
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         def infected = SplunkSteps.getInfectedComponentCounts(response, "impacted_artifacts{}")
-        def expected = SplunkSteps.getExpectedComponentCounts(license_issues, security_issues)
+        def expected = XraySteps.getExpectedComponentCounts(license_issues, security_issues)
 
         Assert.assertEquals(infected, expected)
         Reporter.log("- Splunk. Xray, Violations, Top Impacted Artifacts. " +
@@ -1027,7 +1027,7 @@ class SplunkTest extends DataAnalyticsSteps{
                             /rex field=impacted_artifacts{} "(?<impacted_artifacts>.*)" | return 500000 / +
                             '$impacted_artifacts ] | stats count(username) by repo_path | rename repo_path as impacted_artifact'
 
-        def expectedArtifactCount = SplunkSteps.getExpectedComponentCounts(license_issues, security_issues).size()
+        def expectedArtifactCount = XraySteps.getExpectedComponentCounts(license_issues, security_issues).size()
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         Assert.assertEquals(response.jsonPath().getList("results").size(), expectedArtifactCount)
         Reporter.log("- Splunk. Xray, Violations, Top Impacted Artifact by Count of User Downloads. " +
@@ -1042,7 +1042,7 @@ class SplunkTest extends DataAnalyticsSteps{
                             '"(?<impacted_artifacts>.*)" | return 500000 $impacted_artifacts ] | ' +
                             /stats count(ip) by repo_path | rename repo_path as impacted_artifact/
 
-        def expectedArtifactCount = SplunkSteps.getExpectedComponentCounts(license_issues, security_issues).size()
+        def expectedArtifactCount = XraySteps.getExpectedComponentCounts(license_issues, security_issues).size()
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         Assert.assertEquals(response.jsonPath().getList("results").size(), expectedArtifactCount)
         Reporter.log("- Splunk. Xray, Violations, Top Impacted Artifact by Count of IP Download. " +
@@ -1054,7 +1054,7 @@ class SplunkTest extends DataAnalyticsSteps{
         def search_string = /search=search log_source="jfrog.xray.siem.vulnerabilities" cve!="null" earliest=$earliest | stats  count by cve/
         Response response = splunk.splunkSearchResults(splunk_username, splunk_password, splunkBaseURL, search_string)
         def cveCounts = SplunkSteps.getCVECounts(response)
-        def expectedCVECounts = SplunkSteps.getExpectedCVECounts(security_issues)
+        def expectedCVECounts = XraySteps.getExpectedCVECounts(security_issues)
 
         Assert.assertEquals(cveCounts, expectedCVECounts)
         Reporter.log("- Splunk. Xray, Violations, Top Vulnerabilities. " +

--- a/src/test/groovy/tests/SplunkTest.groovy
+++ b/src/test/groovy/tests/SplunkTest.groovy
@@ -967,10 +967,10 @@ class SplunkTest extends DataAnalyticsSteps{
             Reporter.log("- Splunk. Xray, Violations, Violation Types over Time (Stats). SPLUNK RETURNS NO RESULTS", true)
         } else {
             if ("License" in results.first()) {
-                licenseViolationCount = results.stream().reduce(0, (int count, data) -> count + Integer.parseInt(data["License"].toString()))
+                licenseViolationCount = results.stream().reduce(0, { (int count, data) -> count + Integer.parseInt(data["License"].toString()) })
             }
             if ("Security" in results.first()) {
-                securityViolationCount = results.stream().reduce(0, (int count, data) -> count + Integer.parseInt(data["Security"].toString()) )
+                securityViolationCount = results.stream().reduce(0, { (int count, data) -> count + Integer.parseInt(data["Security"].toString()) } )
             }
         }
         def expected = SplunkSteps.getExpectedViolationCounts(license_issues, security_issues)


### PR DESCRIPTION
This PR includes tests to verify that data generated in GenerateXrayDataTest.groovy are populated in the Datadog Xray Violations dashboard. In doing so, many functions from the Splunk tests were reused, so these functions were moved to a more general place in XraySteps.groovy.